### PR TITLE
fix: install maturin in semantic release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,10 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install toml-cli
-        run: cargo install toml-cli
+      - name: Install build tools
+        run: |
+          cargo install toml-cli
+          uv tool install maturin
 
       - name: Semantic Release
         id: semantic-release


### PR DESCRIPTION
## Summary
- Install maturin in the release workflow's semantic release job
- The `build_command = "maturin build --release"` in pyproject.toml was failing with exit code 127 (command not found)

This was the last blocker preventing automated releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)