### PR TITLE
fix: remove x86 (32-bit) Linux target from build matrices

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,8 +22,6 @@ jobs:
           - runner: ubuntu-latest
             target: x86_64
           - runner: ubuntu-latest
-            target: x86
-          - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
@@ -57,8 +55,6 @@ jobs:
         platform:
           - runner: ubuntu-latest
             target: x86_64
-          - runner: ubuntu-latest
-            target: x86
           - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,6 @@ jobs:
           - runner: ubuntu-latest
             target: x86_64
           - runner: ubuntu-latest
-            target: x86
-          - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
@@ -125,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7]
+        target: [x86_64, aarch64, armv7]
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary
- Remove x86 (32-bit) Linux target from `CI.yml` and `release.yml` build matrices (both manylinux and musllinux)
- Python 3.x is no longer available for 32-bit Linux on Ubuntu 24.04, causing these builds to fail
- Windows x86 target is kept as Windows still supports 32-bit Python

## Test plan
- [ ] CI build workflow passes without x86 Linux failures
- [ ] Release workflow triggers on merge and successfully publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)