### PR TITLE
fix: prevent cargo lock updates in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: clippy
         name: Rust linting (cargo clippy)
         description: Lint Rust code with cargo clippy
-        entry: cargo clippy --all-targets --all-features -- -D warnings
+        entry: cargo clippy --locked --all-targets --all-features -- -D warnings
         language: system
         files: \.rs$
         pass_filenames: false
@@ -44,7 +44,7 @@ repos:
       - id: cargo-test
         name: Rust testing (cargo test)
         description: Run Rust tests
-        entry: cargo test --all-features
+        entry: cargo test --locked --all-features
         language: system
         files: \.rs$
         pass_filenames: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "typeset-py"
-version = "2.0.8"
+version = "2.1.1"
 dependencies = [
  "lazy_static",
  "pest",


### PR DESCRIPTION
## Summary
- Add `--locked` flag to `cargo clippy` and `cargo test` pre-commit hooks
- Prevents cargo from downloading newer compatible dependency versions during hook execution
- Fixes "files were modified by this hook" failures when `Cargo.lock` gets updated

## Test plan
- [ ] Pre-commit Hooks CI job passes (the one that was previously failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)