### PR TITLE
fix: use macos-14 runner for x86_64 builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-14
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
             target: x64
           - runner: windows-latest
             target: x86
-          - runner: macos-13
+          - runner: macos-14
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "typeset-py"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "lazy_static",
  "pest",


### PR DESCRIPTION
## Summary
- Replace `macos-13` with `macos-14` for x86_64 builds in both CI and release workflows
- `macos-13` runners keep getting cancelled, blocking the Publish job in the release pipeline
- `macos-14` (Apple Silicon) can cross-compile x86_64 targets via maturin

## Context
v2.1.1 and v2.1.2 releases both failed to publish to PyPI because the `macos-13` build was cancelled, which prevents the Publish job from running.

## Test plan
- [ ] CI passes with macos-14 building x86_64 target
- [ ] Release pipeline completes and publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)